### PR TITLE
Switch back to typhoeus as less dependancy pain

### DIFF
--- a/.openapi-generator/FILES
+++ b/.openapi-generator/FILES
@@ -157,15 +157,4 @@ lib/slipstream_client/models/webhook_subscription_details.rb
 lib/slipstream_client/models/webhook_subscription_headers_inner.rb
 lib/slipstream_client/version.rb
 slipstream_client.gemspec
-spec/api/payments_api_spec.rb
-spec/models/create_payment_account_request_spec.rb
-spec/models/create_payment_request_spec.rb
-spec/models/payment_account_created_response_onboarding_link_spec.rb
-spec/models/payment_account_created_response_onboarding_session_spec.rb
-spec/models/payment_account_created_response_spec.rb
-spec/models/payment_account_details_spec.rb
-spec/models/payment_account_status_spec.rb
-spec/models/payment_change_summary_spec.rb
-spec/models/payment_details_spec.rb
-spec/models/payment_provider_spec.rb
 spec/spec_helper.rb

--- a/lib/slipstream_client/api_client.rb
+++ b/lib/slipstream_client/api_client.rb
@@ -15,9 +15,7 @@ require 'json'
 require 'logger'
 require 'tempfile'
 require 'time'
-require 'faraday'
-require 'faraday/multipart' if Gem::Version.new(Faraday::VERSION) >= Gem::Version.new('2.0')
-require 'filemagic'
+require 'typhoeus'
 
 
 module SlipstreamClient
@@ -48,45 +46,39 @@ module SlipstreamClient
     # Call an API with given options.
     #
     # @return [Array<(Object, Integer, Hash)>] an array of 3 elements:
-    #   the data deserialized from response body (could be nil), response status code and response headers.
+    #   the data deserialized from response body (may be a Tempfile or nil), response status code and response headers.
     def call_api(http_method, path, opts = {})
-      stream = nil
-      begin
-        response = connection(opts).public_send(http_method.to_sym.downcase) do |req|
-          request = build_request(http_method, path, req, opts)
-          stream = download_file(request) if opts[:return_type] == 'File' || opts[:return_type] == 'Binary'
-        end
+      request = build_request(http_method, path, opts)
+      tempfile = download_file(request) if opts[:return_type] == 'File'
+      response = request.run
 
-        if config.debugging
-          config.logger.debug "HTTP response body ~BEGIN~\n#{response.body}\n~END~\n"
-        end
-
-        unless response.success?
-          if response.status == 0 && response.respond_to?(:return_message)
-            # Errors from libcurl will be made visible here
-            fail ApiError.new(code: 0,
-                              message: response.return_message)
-          else
-            fail ApiError.new(code: response.status,
-                              response_headers: response.headers,
-                              response_body: response.body),
-                 response.reason_phrase
-          end
-        end
-      rescue Faraday::TimeoutError
-        fail ApiError.new('Connection timed out')
-      rescue Faraday::ConnectionFailed
-        fail ApiError.new('Connection failed')
+      if @config.debugging
+        @config.logger.debug "HTTP response body ~BEGIN~\n#{response.body}\n~END~\n"
       end
 
-      if opts[:return_type] == 'File' || opts[:return_type] == 'Binary'
-        data = deserialize_file(response, stream)
+      unless response.success?
+        if response.timed_out?
+          fail ApiError.new('Connection timed out')
+        elsif response.code == 0
+          # Errors from libcurl will be made visible here
+          fail ApiError.new(:code => 0,
+                            :message => response.return_message)
+        else
+          fail ApiError.new(:code => response.code,
+                            :response_headers => response.headers,
+                            :response_body => response.body),
+               response.status_message
+        end
+      end
+
+      if opts[:return_type] == 'File'
+        data = tempfile
       elsif opts[:return_type]
         data = deserialize(response, opts[:return_type])
       else
         data = nil
       end
-      return data, response.status, response.headers
+      return data, response.code, response.headers
     end
 
     # Builds the HTTP request
@@ -97,33 +89,47 @@ module SlipstreamClient
     # @option opts [Hash] :query_params Query parameters
     # @option opts [Hash] :form_params Query parameters
     # @option opts [Object] :body HTTP body (JSON/XML)
-    # @return [Faraday::Request] A Faraday Request
-    def build_request(http_method, path, request, opts = {})
+    # @return [Typhoeus::Request] A Typhoeus Request
+    def build_request(http_method, path, opts = {})
       url = build_request_url(path, opts)
       http_method = http_method.to_sym.downcase
 
       header_params = @default_headers.merge(opts[:header_params] || {})
       query_params = opts[:query_params] || {}
       form_params = opts[:form_params] || {}
+      follow_location = opts[:follow_location] || true
 
       update_params_for_auth! header_params, query_params, opts[:auth_names]
 
+      # set ssl_verifyhosts option based on @config.verify_ssl_host (true/false)
+      _verify_ssl_host = @config.verify_ssl_host ? 2 : 0
+
+      req_opts = {
+        :method => http_method,
+        :headers => header_params,
+        :params => query_params,
+        :params_encoding => @config.params_encoding,
+        :timeout => @config.timeout,
+        :ssl_verifypeer => @config.verify_ssl,
+        :ssl_verifyhost => _verify_ssl_host,
+        :sslcert => @config.cert_file,
+        :sslkey => @config.key_file,
+        :verbose => @config.debugging,
+        :followlocation => follow_location
+      }
+
+      # set custom cert, if provided
+      req_opts[:cainfo] = @config.ssl_ca_cert if @config.ssl_ca_cert
+
       if [:post, :patch, :put, :delete].include?(http_method)
         req_body = build_request_body(header_params, form_params, opts[:body])
-        if config.debugging
-          config.logger.debug "HTTP request body param ~BEGIN~\n#{req_body}\n~END~\n"
+        req_opts.update :body => req_body
+        if @config.debugging
+          @config.logger.debug "HTTP request body param ~BEGIN~\n#{req_body}\n~END~\n"
         end
       end
-      request.headers = header_params
-      request.body = req_body
 
-      # Overload default options only if provided
-      request.options.params_encoder = config.params_encoder if config.params_encoder
-      request.options.timeout        = config.timeout        if config.timeout
-
-      request.url url
-      request.params = query_params
-      request
+      Typhoeus::Request.new(url, req_opts)
     end
 
     # Builds the HTTP request body
@@ -134,17 +140,13 @@ module SlipstreamClient
     # @return [String] HTTP body data in the form of string
     def build_request_body(header_params, form_params, body)
       # http form
-      if header_params['Content-Type'] == 'application/x-www-form-urlencoded'
-        data = URI.encode_www_form(form_params)
-      elsif header_params['Content-Type'] == 'multipart/form-data'
+      if header_params['Content-Type'] == 'application/x-www-form-urlencoded' ||
+          header_params['Content-Type'] == 'multipart/form-data'
         data = {}
         form_params.each do |key, value|
           case value
-          when ::File, ::Tempfile
-            filemagic = FileMagic.new(FileMagic::MAGIC_MIME)
-            data[key] = Faraday::FilePart.new(value.path, filemagic.file(value.path, true))
-          when ::Array, nil
-            # let Faraday handle Array and nil parameters
+          when ::File, ::Array, nil
+            # let typhoeus handle File, Array and nil parameters
             data[key] = value
           else
             data[key] = value.to_s
@@ -158,24 +160,19 @@ module SlipstreamClient
       data
     end
 
+    # Save response body into a file in (the defined) temporary folder, using the filename
+    # from the "Content-Disposition" header if provided, otherwise a random filename.
+    # The response body is written to the file in chunks in order to handle files which
+    # size is larger than maximum Ruby String or even larger than the maximum memory a Ruby
+    # process can use.
+    #
+    # @see Configuration#temp_folder_path
+    #
+    # @return [Tempfile] the tempfile generated
     def download_file(request)
-      stream = []
-
-      # handle streaming Responses
-      request.options.on_data = Proc.new do |chunk, overall_received_bytes|
-        stream << chunk
-      end
-      stream
-    end
-
-    def deserialize_file(response, stream)
-      body = response.body
-      if @config.return_binary_data == true
-        # return byte stream
-        encoding = body.encoding
-        stream.join.force_encoding(encoding)
-      else
-        # return file instead of binary data
+      tempfile = nil
+      encoding = nil
+      request.on_headers do |response|
         content_disposition = response.headers['Content-Disposition']
         if content_disposition && content_disposition =~ /filename=/i
           filename = content_disposition[/filename=['"]?([^'"\s]+)['"]?/, 1]
@@ -184,61 +181,26 @@ module SlipstreamClient
           prefix = 'download-'
         end
         prefix = prefix + '-' unless prefix.end_with?('-')
-        encoding = body.encoding
+        encoding = response.body.encoding
         tempfile = Tempfile.open(prefix, @config.temp_folder_path, encoding: encoding)
-        tempfile.write(stream.join.force_encoding(encoding))
+      end
+      request.on_body do |chunk|
+        chunk.force_encoding(encoding)
+        tempfile.write(chunk)
+      end
+      # run the request to ensure the tempfile is created successfully before returning it
+      request.run
+      if tempfile
         tempfile.close
-        config.logger.info "Temp file written to #{tempfile.path}, please copy the file to a proper folder "\
+        @config.logger.info "Temp file written to #{tempfile.path}, please copy the file to a proper folder "\
                             "with e.g. `FileUtils.cp(tempfile.path, '/new/file/path')` otherwise the temp file "\
                             "will be deleted automatically with GC. It's also recommended to delete the temp file "\
                             "explicitly with `tempfile.delete`"
-        tempfile
+      else
+        fail ApiError.new("Failed to create the tempfile based on the HTTP response from the server: #{request.inspect}") 
       end
-    end
 
-    def connection(opts)
-      opts[:header_params]['Content-Type'] == 'multipart/form-data' ? connection_multipart : connection_regular
-    end
-
-    def connection_multipart
-      @connection_multipart ||= build_connection do |conn|
-        conn.request :multipart
-        conn.request :url_encoded
-      end
-    end
-
-    def connection_regular
-      @connection_regular ||= build_connection
-    end
-
-    def build_connection
-      Faraday.new(url: config.base_url, ssl: ssl_options, proxy: config.proxy) do |conn|
-        basic_auth(conn)
-        config.configure_middleware(conn)
-        yield(conn) if block_given?
-        conn.adapter(Faraday.default_adapter)
-        config.configure_connection(conn)
-      end
-    end
-
-    def ssl_options
-      {
-        ca_file: config.ssl_ca_file,
-        verify: config.ssl_verify,
-        verify_mode: config.ssl_verify_mode,
-        client_cert: config.ssl_client_cert,
-        client_key: config.ssl_client_key
-      }
-    end
-
-    def basic_auth(conn)
-      if config.username && config.password
-        if Gem::Version.new(Faraday::VERSION) >= Gem::Version.new('2.0')
-          conn.request(:authorization, :basic, config.username, config.password)
-        else
-          conn.request(:basic_auth, config.username, config.password)
-        end
-      end
+      tempfile
     end
 
     # Check if the given MIME is a JSON MIME.

--- a/lib/slipstream_client/configuration.rb
+++ b/lib/slipstream_client/configuration.rb
@@ -108,39 +108,40 @@ module SlipstreamClient
     # @note Do NOT set it to false in production code, otherwise you would face multiple types of cryptographic attacks.
     #
     # @return [true, false]
-    attr_accessor :ssl_verify
+    attr_accessor :verify_ssl
 
     ### TLS/SSL setting
-    # Any `OpenSSL::SSL::` constant (see https://ruby-doc.org/stdlib-2.5.1/libdoc/openssl/rdoc/OpenSSL/SSL.html)
+    # Set this to false to skip verifying SSL host name
+    # Default to true.
     #
     # @note Do NOT set it to false in production code, otherwise you would face multiple types of cryptographic attacks.
     #
-    attr_accessor :ssl_verify_mode
+    # @return [true, false]
+    attr_accessor :verify_ssl_host
 
     ### TLS/SSL setting
     # Set this to customize the certificate file to verify the peer.
     #
     # @return [String] the path to the certificate file
-    attr_accessor :ssl_ca_file
+    #
+    # @see The `cainfo` option of Typhoeus, `--cert` option of libcurl. Related source code:
+    # https://github.com/typhoeus/typhoeus/blob/master/lib/typhoeus/easy_factory.rb#L145
+    attr_accessor :ssl_ca_cert
 
     ### TLS/SSL setting
     # Client certificate file (for client certificate)
-    attr_accessor :ssl_client_cert
+    attr_accessor :cert_file
 
     ### TLS/SSL setting
     # Client private key file (for client certificate)
-    attr_accessor :ssl_client_key
+    attr_accessor :key_file
 
-    ### Proxy setting
-    # HTTP Proxy settings
-    attr_accessor :proxy
-
-    # Set this to customize parameters encoder of array parameter.
-    # Default to nil. Faraday uses NestedParamsEncoder when nil.
+    # Set this to customize parameters encoding of array parameter with multi collectionFormat.
+    # Default to nil.
     #
-    # @see The params_encoder option of Faraday. Related source code:
-    # https://github.com/lostisland/faraday/tree/main/lib/faraday/encoders
-    attr_accessor :params_encoder
+    # @see The params_encoding option of Ethon. Related source code:
+    # https://github.com/typhoeus/ethon/blob/master/lib/ethon/easy/queryable.rb#L96
+    attr_accessor :params_encoding
 
 
     attr_accessor :inject_format
@@ -158,17 +159,12 @@ module SlipstreamClient
       @api_key = {}
       @api_key_prefix = {}
       @client_side_validation = true
-      @ssl_verify = true
-      @ssl_verify_mode = nil
-      @ssl_ca_file = nil
-      @ssl_client_cert = nil
-      @ssl_client_key = nil
-      @middlewares = Hash.new { |h, k| h[k] = [] }
-      @configure_connection_blocks = []
-      @timeout = 60
-      # return data as binary instead of file
-      @return_binary_data = false
-      @params_encoder = nil
+      @verify_ssl = true
+      @verify_ssl_host = true
+      @cert_file = nil
+      @key_file = nil
+      @timeout = 0
+      @params_encoding = nil
       @debugging = false
       @inject_format = false
       @force_ending_format = false
@@ -319,86 +315,6 @@ module SlipstreamClient
       url
     end
 
-    # Configure Faraday connection directly.
-    #
-    # ```
-    # c.configure_faraday_connection do |conn|
-    #   conn.use Faraday::HttpCache, shared_cache: false, logger: logger
-    #   conn.response :logger, nil, headers: true, bodies: true, log_level: :debug do |logger|
-    #     logger.filter(/(Authorization: )(.*)/, '\1[REDACTED]')
-    #   end
-    # end
-    #
-    # c.configure_faraday_connection do |conn|
-    #   conn.adapter :typhoeus
-    # end
-    # ```
-    #
-    # @param block [Proc] `#call`able object that takes one arg, the connection
-    def configure_faraday_connection(&block)
-      @configure_connection_blocks << block
-    end
-
-    def configure_connection(conn)
-      @configure_connection_blocks.each do |block|
-        block.call(conn)
-      end
-    end
-
-    # Adds middleware to the stack
-    def use(*middleware)
-      set_faraday_middleware(:use, *middleware)
-    end
-
-    # Adds request middleware to the stack
-    def request(*middleware)
-      set_faraday_middleware(:request, *middleware)
-    end
-
-    # Adds response middleware to the stack
-    def response(*middleware)
-      set_faraday_middleware(:response, *middleware)
-    end
-
-    # Adds Faraday middleware setting information to the stack
-    #
-    # @example Use the `set_faraday_middleware` method to set middleware information
-    #   config.set_faraday_middleware(:request, :retry, max: 3, methods: [:get, :post], retry_statuses: [503])
-    #   config.set_faraday_middleware(:response, :logger, nil, { bodies: true, log_level: :debug })
-    #   config.set_faraday_middleware(:use, Faraday::HttpCache, store: Rails.cache, shared_cache: false)
-    #   config.set_faraday_middleware(:insert, 0, FaradayMiddleware::FollowRedirects, { standards_compliant: true, limit: 1 })
-    #   config.set_faraday_middleware(:swap, 0, Faraday::Response::Logger)
-    #   config.set_faraday_middleware(:delete, Faraday::Multipart::Middleware)
-    #
-    # @see https://github.com/lostisland/faraday/blob/v2.3.0/lib/faraday/rack_builder.rb#L92-L143
-    def set_faraday_middleware(operation, key, *args, &block)
-      unless [:request, :response, :use, :insert, :insert_before, :insert_after, :swap, :delete].include?(operation)
-        fail ArgumentError, "Invalid faraday middleware operation #{operation}. Must be" \
-                            " :request, :response, :use, :insert, :insert_before, :insert_after, :swap or :delete."
-      end
-
-      @middlewares[operation] << [key, args, block]
-    end
-    ruby2_keywords(:set_faraday_middleware) if respond_to?(:ruby2_keywords, true)
-
-    # Set up middleware on the connection
-    def configure_middleware(connection)
-      return if @middlewares.empty?
-
-      [:request, :response, :use, :insert, :insert_before, :insert_after, :swap].each do |operation|
-        next unless @middlewares.key?(operation)
-
-        @middlewares[operation].each do |key, args, block|
-          connection.builder.send(operation, key, *args, &block)
-        end
-      end
-
-      if @middlewares.key?(:delete)
-        @middlewares[:delete].each do |key, _args, _block|
-          connection.builder.delete(key)
-        end
-      end
-    end
 
   end
 end

--- a/lib/slipstream_client/version.rb
+++ b/lib/slipstream_client/version.rb
@@ -11,5 +11,5 @@ Generator version: 7.4.0
 =end
 
 module SlipstreamClient
-  VERSION = '1.0.0'
+  VERSION = '1.0.5'
 end

--- a/lib/slipstream_client/version.rb
+++ b/lib/slipstream_client/version.rb
@@ -11,5 +11,5 @@ Generator version: 7.4.0
 =end
 
 module SlipstreamClient
-  VERSION = '1.0.3'
+  VERSION = '1.0.0'
 end

--- a/openapi-generator-gem-config.yaml
+++ b/openapi-generator-gem-config.yaml
@@ -6,5 +6,6 @@ gem_description: |
   # To build
   `openapi-generator generate -i https://dev.slipstream.hsone.app/swagger/v1/swagger.json -g ruby -c openapi-generator-gem-config.yaml -o . --git-repo-id slipstream-gem --git-user-id dentally`
 
+  increment version number in lib/slipstream_client/version.rb
   # Then rebuild after bumping the gem version where appropriate
   gem build slipstream_client.gemspec

--- a/openapi-generator-gem-config.yaml
+++ b/openapi-generator-gem-config.yaml
@@ -1,10 +1,10 @@
 gemName: slipstream_client
-library: faraday
+library: typhoeus
 gem_description: |
   ### This gem is auto generated via [openapi-generator](https://github.com/OpenAPITools/openapi-generator) from the slipstream open api spec as follows
 
   # To build
-  `openapi-generator generate -i https://slipstream.hsone.app/swagger/v1/swagger.json -g ruby -c openapi-generator-gem-config.yaml -o . --git-repo-id slipstream-gem --git-user-id dentally`
+  `openapi-generator generate -i https://dev.slipstream.hsone.app/swagger/v1/swagger.json -g ruby -c openapi-generator-gem-config.yaml -o . --git-repo-id slipstream-gem --git-user-id dentally`
 
   # Then rebuild after bumping the gem version where appropriate
   gem build slipstream_client.gemspec

--- a/slipstream_client.gemspec
+++ b/slipstream_client.gemspec
@@ -28,9 +28,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.7"
   s.metadata    = {}
 
-  s.add_runtime_dependency 'faraday', '>= 1.0.1', '< 3.0'
-  s.add_runtime_dependency 'faraday-multipart'
-  s.add_runtime_dependency 'ruby-filemagic'
+  s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
 


### PR DESCRIPTION
Although we already use faraday switching the client to use it
introduces ruby-filemagic as a dependancy which in turn requires
libmagic lib to be installed on all machines just to run bundle
install. much less of a head ache to just use faraday
