### PR TITLE
Remove duplicate key in auth_settings hash

### DIFF
--- a/lib/slipstream_client/configuration.rb
+++ b/lib/slipstream_client/configuration.rb
@@ -241,13 +241,6 @@ module SlipstreamClient
             key: 'Authorization',
             value: "Bearer #{access_token_with_refresh}"
           },
-        'azure_auth' =>
-          {
-            type: 'oauth2',
-            in: 'header',
-            key: 'Authorization',
-            value: "Bearer #{access_token_with_refresh}"
-          },
         'api_key' =>
           {
             type: 'api_key',


### PR DESCRIPTION
This was raising a warning. The sections are duplicates so it's safe to remove one.