### PR TITLE
Change 'Items' to 'Summary'

### DIFF
--- a/lib/slipstream_client/models/billing_summary_details.rb
+++ b/lib/slipstream_client/models/billing_summary_details.rb
@@ -14,7 +14,7 @@ require 'date'
 require 'time'
 
 module SlipstreamClient
-  # The billing summary details 
+  # The billing summary details
   class BillingSummaryDetails
     # The Start Date of the billing summary period
     attr_accessor :date_from
@@ -30,7 +30,7 @@ module SlipstreamClient
       {
         :'date_from' => :'DateFrom',
         :'date_to' => :'DateTo',
-        :'items' => :'Items'
+        :'items' => :'Summary'
       }
     end
 


### PR DESCRIPTION
### Description
The attributes coming through are structured with "Summary" being the key and the summary items being an array. It was breaking since it was looking for an "Items" key. This fixes that by setting the correct attribute map

### Manual Testing
There is technically no blast zone since this is a Dentally only gem and Dentally doesn't use this function anyway

- [x] Ran it locally and the summary was returned properly:
```
#<SlipstreamClient::BillingSummaryDetails:0x000000013b8a8d88
 @items=
  [#<SlipstreamClient::BillingSummary:0x000000014cb5c280 @pax=6, @sku="COMM.SMS-3N", @sku_description="COMM - SMS [Success]">,
   #<SlipstreamClient::BillingSummary:0x000000014cab7a00 @pax=17, @sku="COMM.SMS-NL", @sku_description="COMM - SMS [Failure]">]>
 ```